### PR TITLE
Add Solid Launcher and XiaoMi Launchers

### DIFF
--- a/ShortcutBadger/src/main/AndroidManifest.xml
+++ b/ShortcutBadger/src/main/AndroidManifest.xml
@@ -21,4 +21,7 @@
     <!--for apex-->
     <uses-permission android:name="com.anddoes.launcher.permission.UPDATE_COUNT"/>
 
+    <!--for solid-->
+    <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE"/>
+
 </manifest>

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
@@ -1,0 +1,32 @@
+package me.leolin.shortcutbadger.impl;
+
+import android.content.Context;
+import android.content.Intent;
+
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+/**
+ * @author MajeurAndroid
+ */
+public class SolidHomeBadger extends ShortcutBadger {
+
+  private static final String INTENT_UPDATE_COUNTER = "com.majeur.launcher.intent.action.UPDATE_BADGE";
+  private static final String PACKAGENAME = "com.majeur.launcher.intent.extra.BADGE_PACKAGE";
+  private static final String COUNT = "com.majeur.launcher.intent.extra.BADGE_COUNT";
+  private static final String CLASS = "com.majeur.launcher.intent.extra.BADGE_CLASS";
+
+  public SolidHomeBadger(Context context) {
+    super(context);
+  }
+
+  @Override
+  protected void executeBadge(int badgeCount) throws ShortcutBadgeException {
+    Intent intent = new Intent(INTENT_UPDATE_COUNTER);
+    intent.putExtra(PACKAGENAME, getContextPackageName());
+    intent.putExtra(COUNT, badgeCount);
+    intent.putExtra(CLASS, getEntryActivityName());
+    mContext.sendBroadcast(intent);
+  }
+
+}

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
@@ -1,0 +1,40 @@
+package me.leolin.shortcutbadger.impl;
+
+import android.content.Context;
+import android.content.Intent;
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+import java.lang.reflect.Field;
+
+/**
+ * @author leolin
+ */
+public class XiaomiHomeBadger extends ShortcutBadger {
+
+  public static final String INTENT_ACTION = "android.intent.action.APPLICATION_MESSAGE_UPDATE";
+  public static final String EXTRA_UPDATE_APP_COMPONENT_NAME = "android.intent.extra.update_application_component_name";
+  public static final String EXTRA_UPDATE_APP_MSG_TEXT = "android.intent.extra.update_application_message_text";
+
+  public XiaomiHomeBadger(Context context) {
+    super(context);
+  }
+
+  @Override
+  protected void executeBadge(int badgeCount) throws ShortcutBadgeException {
+    try {
+      Class miuiNotificationClass = Class.forName("android.app.MiuiNotification");
+      Object miuiNotification = miuiNotificationClass.newInstance();
+      Field field = miuiNotification.getClass().getDeclaredField("messageCount");
+      field.setAccessible(true);
+      field.set(miuiNotification, String.valueOf(badgeCount == 0 ? "" : badgeCount));
+    } catch (Exception e) {
+      Intent localIntent = new Intent(
+          INTENT_ACTION);
+      localIntent.putExtra(EXTRA_UPDATE_APP_COMPONENT_NAME, getContextPackageName() + "/" + getEntryActivityName());
+      localIntent.putExtra(EXTRA_UPDATE_APP_MSG_TEXT, String.valueOf(badgeCount == 0 ? "" : badgeCount));
+      mContext.sendBroadcast(localIntent);
+    }
+  }
+
+}


### PR DESCRIPTION
XiaoMi does not seem to need permissions, according to the net...
also changed the home package check. adapted from a former version of upstream

This also includes the fix in #3
